### PR TITLE
added alertLocation parameter to reportProblem

### DIFF
--- a/CENTRAL_PACKAGE/js/module.reportProblem.js
+++ b/CENTRAL_PACKAGE/js/module.reportProblem.js
@@ -6,6 +6,7 @@ angular.module('reportProblem').component('ocaReportProblem', {
     buttonText: '@',
     reportUrl: '@',
     reportVendor: '@',
+    alertLocation:'@',
     parentCtrl: '<'
   },
   require: {
@@ -102,6 +103,7 @@ angular.module('reportProblem').component('ocaReportProblem', {
     this.buttonText = this.buttonText || (reportProblem.hasOwnProperty("buttonText") ? reportProblem.buttonText : reportProblemDefault.buttonText);
     this.reportUrl = this.reportUrl || (reportProblem.hasOwnProperty("reportUrl") ? reportProblem.reportUrl : reportProblemDefault.reportUrl);
     this.reportVendor = this.reportVendor || (reportProblem.hasOwnProperty("reportVendor") ? reportProblem.reportVendor : reportProblemDefault.reportVendor);
+    this.alertLocation = this.alertLocation || (reportProblem.hasOwnProperty("alertLocation") ? reportProblem.alertLocation : reportProblemDefault.alertLocation);
     this.showLocations = ['/fulldisplay', '/openurl'];
     this.$onInit = function () {
       this.targetUrl = this.reportUrl + $httpParamSerializer($location.search());
@@ -211,9 +213,13 @@ angular.module('reportProblem').component('ocaReportProblem', {
   }]
 }).run(['$templateCache', 'reportProblem', 'reportProblemDefault', function ($templateCache, reportProblem, reportProblemDefault) {
   if (reportProblem.hasOwnProperty("enabledDefault") ? reportProblem.enabledDefault : reportProblemDefault.enabledDefault) {
-    $templateCache.put('components/search/fullView/fullViewServiceContainer/full-view-service-container.html', $templateCache.get('components/search/fullView/fullViewServiceContainer/full-view-service-container.html')
-      .replace('<prm-login-alma-mashup', '<oca-report-problem ng-if="$ctrl.index == 1 && $ctrl.service.serviceName===\'activate\'" parent-ctrl="$ctrl"></oca-report-problem><prm-login-alma-mashup') // get/view it
-      .replace('<prm-full-view-service-container-after', '<oca-report-problem ng-if="$ctrl.index == 1 && $ctrl.service.serviceName!==\'activate\'" parent-ctrl="$ctrl"></oca-report-problem><prm-full-view-service-container-after')); // everything else catch-all
+    var afterThisElement = 'prm-login-alma-mashup';
+    if (reportProblem.hasOwnProperty("alertLocation") && reportProblem.alertLocation === "bottom") {
+      afterThisElement = 'prm-alma-mashup';
+    }
+    console.log('reportProblem.hasOwnProperty("messageText")', reportProblem.messageText);
+    $templateCache.put('components/search/fullView/fullViewServiceContainer/full-view-service-container.html', $templateCache.get('components/search/fullView/fullViewServiceContainer/full-view-service-container.html').replace('</' + afterThisElement + '>', '</' + afterThisElement + '><oca-report-problem ng-if="$ctrl.index == 1 && $ctrl.service.serviceName===\'activate\'" parent-ctrl="$ctrl"></oca-report-problem>') // get/view it
+    .replace('<prm-full-view-service-container-after', '<oca-report-problem ng-if="$ctrl.index == 1 && $ctrl.service.serviceName!==\'activate\'" parent-ctrl="$ctrl"></oca-report-problem><prm-full-view-service-container-after')); // everything else catch-all
   }
 }]);
 
@@ -226,6 +232,7 @@ angular.module('reportProblem').value('reportProblem', {}).value('reportProblemD
   format: 'html', //html | plaintext | markdown
   reportUrl: 'https://library.calstate.edu/primo-gateway/',
   reportVendor: 'email',
+  alertLocation: 'top',
   messageText: 'See something that doesn\'t look right?',
   buttonText: 'Report a Problem',
   subject: 'Problem report',


### PR DESCRIPTION
This is just a suggestion for review. I'm not sure if there's a more formal feature request process. For instance I could put this in as an issue with [FEATURE REQUEST] in the title but that would probably leave out many of the people who would have input anyway.

We implemented the reportProblem feature but have found that patrons often give up too quickly and use it before trying other options that are listed below the box. Our local Primo group would prefer to put the reportProblem box further down. My small code change is meant to default to the current setting which is putting <oca-report-problem> after <prm-login-alma-mashup> and allow setting it to go after <prm-alma-mashup> using a new parameter called "alertLocation". The default is "top" and to put it further down the parameter should be set to "bottom".